### PR TITLE
fix: Fix ViewChild and ng-template example in post

### DIFF
--- a/_posts/2018-05-26-dynamic-UI-with-cdk-portals.md
+++ b/_posts/2018-05-26-dynamic-UI-with-cdk-portals.md
@@ -49,7 +49,7 @@ Basically in our specific demo app,
 The page actions could be defined as follows within our `ContactListComponent`
 
 ```html
-<ng-template>
+<ng-template #pageActions>
 	<button type="button" class="toolbar-btn" mat-icon-button (click)="onSave()">
   		<mat-icon>add</mat-icon>
 	</button>


### PR DESCRIPTION
Specifying the template reference on the `ng-template` so it can be fetched by the `ViewChild` query.